### PR TITLE
feat(omnievent): add GetLatestOccurrence endpoint

### DIFF
--- a/omnievent/events.proto
+++ b/omnievent/events.proto
@@ -20,6 +20,9 @@ service OmniEventService {
 
   // Get historical events (batch request)
   rpc GetHistoricalEvents(GetHistoricalEventsRequest) returns (GetHistoricalEventsResponse);
+
+  // Get the most recent occurrence of any of the specified events
+  rpc GetLatestOccurrence(GetLatestOccurrenceRequest) returns (EventOccurrence);
 }
 
 // Request message for registering a new event
@@ -80,6 +83,15 @@ message GetHistoricalEventsRequest {
 message GetHistoricalEventsResponse {
   // List of event occurrences
   repeated EventOccurrence occurrences = 1;
+}
+
+// Request for the last occurrence of historical events
+message GetLatestOccurrenceRequest {
+  // Uuid uniquely representing the event
+  repeated bytes event_uuids = 1;
+
+  // Filter the event occurrences.
+  EventOccurrenceFilter filter = 2;
 }
 
 // Represents a registered event


### PR DESCRIPTION
`GetLatestOccurrence` is used to obtain the latest event occurrence from any of the specified events.

Given the following event: `event Subscribed(address indexed subscriber, uint256 indexed subId)`,
this endpoint can be used to obtain the latest occurrence of this event with filters `subscriber == 0x5be724cD0545d42B8F0621778C7F9fF483aa43A7` and `sub_id = 1` as follows:
```bash
> grpcurl -import-path ./dcipher-proto -proto omnievent/events.proto -plaintext -d '{
  "event_uuids": [
    "EnuqBF41WvSiJ7GQFWYa6g==",
    "XvHrxLDFWRmI88CKpk52qA=="
  ],
  "filter": {
    "data_filters": [
      {
        "data_index": 0,
        "address": {
          "exact_values": [
            "W+ckzQVF1CuPBiF3jH+f9IOqQ6c="
          ]
        }
      },
      {
        "data_index": 1,
        "uint": {
          "exact_hex_values": [
            "0x1"
          ]
        }
      }
    ]
  }
}' 127.0.0.1:8089 events.OmniEventService/GetLatestOccurrence
{
  "eventUuid": "XvHrxLDFWRmI88CKpk52qA==",
  "blockInfo": {
    "blockNumber": "2",
    "blockHash": "R96H3M27na9WysPTzLCBWIl6b2LKAzGWsfp0s1EeK9E=",
    "timestamp": "2025-07-10T10:30:10Z"
  },
  "rawLogData": "",
  "eventData": [
    {
      "solType": "address",
      "indexed": true,
      "addressValue": "W+ckzQVF1CuPBiF3jH+f9IOqQ6c="
    },
    {
      "solType": "uint256",
      "indexed": true,
      "intHexValue": "0x1"
    }
  ],
  "chainId": "1337",
  "address": "IO7wOMg7eg81fUq8ZLj2OUJ9evY="
}
```

The latest occurrence is obtained through the block timestamp.